### PR TITLE
Fix lodash version

### DIFF
--- a/contracts/FISSION.sol
+++ b/contracts/FISSION.sol
@@ -349,12 +349,12 @@ library FISSION {
 
     // Get nibbles
 
-    function categoryOf(byte status) public pure returns (uint8 category) {
-        return (uint8(status >> 4));
+    function categoryOf(byte status) public pure returns (byte category) {
+        return status >> 4;
     }
 
-    function reasonOf(byte status) public pure returns (uint8 reason) {
-        return uint8(status & 0x0F);
+    function reasonOf(byte status) public pure returns (byte reason) {
+        return status & 0x0F;
     }
 
     // Localization
@@ -374,11 +374,19 @@ library FISSION {
     }
 
     function isSuccess(byte status) public pure returns (bool) {
-        return reasonOf(status) == 1;
+        return reasonOf(status) == 0x1;
     }
 
     function isFailure(byte status) public pure returns (bool) {
-        return reasonOf(status) == 0;
+        return reasonOf(status) == 0x0;
+    }
+
+    function isCategory(byte status, byte category) public pure returns (bool) {
+        returns categoryOf(status) == category;
+    }
+
+    function isReason(byte status, byte reason) public pure returns (bool) {
+      returns categoryOf(status) == reason;
     }
 
     // `require`s
@@ -407,5 +415,31 @@ library FISSION {
     function requireSuccess(byte status, LocalizationPreferences prefs) public view {
         (bool _, string memory message) = localizeBy(status, prefs);
         requireSuccess(status, message);
+    }
+
+    function requireCategory(byte status, byte category) public view {
+        require(isCategory(status, category));
+    }
+
+    function requireCategory(byte status, byte category, string memory message) public view {
+        require(isCategory(status, category), message);
+    }
+
+    function requireCategory(byte status, byte category, LocalizationPreferences prefs) public view {
+        (bool _, string memory message) = localizeBy(status, prefs);
+        requireCategory(status, category, message);
+    }
+
+    function requireReason(byte status, byte reason) public view {
+        require(isReason(status, reason));
+    }
+
+    function requireReason(byte status, byte reason, string memory message) public view {
+        require(isReason(status, reason), message);
+    }
+
+    function requireReason(byte status, byte reason, LocalizationPreferences prefs) public view {
+        (bool _, string memory message) = localizeBy(status, prefs);
+        requireReason(status, reason, message);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-codes",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0-rc2",
   "description": "Smart contract status codes and helpers",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -41,14 +41,11 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-import": "^2.15.0",
-    "ethereum-localized-messaging": "^1.1.1",
+    "ethereum-localized-messaging": "^2.1.4",
     "ganache-cli": "^6.2.5",
     "mocha": "^5.2.0",
     "solhint": "^1.5.0",
     "solidity-coverage": "^0.5.11",
     "truffle": "^5.0.2"
-  },
-  "dependencies": {
-    "ethereum-localized-messaging": "^2.1.4"
   }
 }


### PR DESCRIPTION
Github warned of minor issue in lodash, where you can overwrite an `Object.assign`. Bumped version numbers of a dependency.