### PR TITLE
Fix lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,14 +41,11 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-import": "^2.15.0",
-    "ethereum-localized-messaging": "^1.1.1",
+    "ethereum-localized-messaging": "^2.1.4",
     "ganache-cli": "^6.2.5",
     "mocha": "^5.2.0",
     "solhint": "^1.5.0",
     "solidity-coverage": "^0.5.11",
     "truffle": "^5.0.2"
-  },
-  "dependencies": {
-    "ethereum-localized-messaging": "^2.1.4"
   }
 }


### PR DESCRIPTION
Github warned of minor issue in lodash, where you can overwrite an `Object.assign`. Bumped version numbers of a dependency.